### PR TITLE
support FRAME_UT

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Loaded 7206 Starlink TLE satellites
 ...
 [2025-04-13 06:35:12,481] [INFO] clearing obstruction map data
 [2025-04-13 06:35:18,793] [INFO] save rtt measurement to data/latency/2025-04-13/ping-10ms-2m-2025-04-13-06-33-18.txt
-[2025-04-13 06:35:19,728] [INFO] save sinr measurement to data/grpc/2025-04-13/PhyRxBeamSnrAvg-2025-04-13-06-33-18.csv
+[2025-04-13 06:35:19,728] [INFO] save sinr measurement to data/grpc/2025-04-13/GRPC_STATUS-2025-04-13-06-33-18.csv
 [2025-04-13 06:35:27,605] [INFO] saved obstruction map data to data/grpc/2025-04-13/obstruction_map-2025-04-13-06-33-18.parquet
 2025-04-13 06:33:27.607699+00:00
 ...
@@ -99,7 +99,7 @@ If successful, you will see the following files in the `data` directory:
     │   └── 2025-04-13
     │       ├── GetStatus-2025-04-13-06-33-18.txt
     │       ├── obstruction_map-2025-04-13-06-33-18.parquet
-    │       └── PhyRxBeamSnrAvg-2025-04-13-06-33-18.csv
+    │       └── GRPC_STATUS-2025-04-13-06-33-18.csv
     ├── latency
     │   └── 2025-04-13
     │       └── ping-10ms-2025-04-13-06-33-18.txt

--- a/starlink/dish.py
+++ b/starlink/dish.py
@@ -196,20 +196,30 @@ def get_obstruction_map():
 
     process_obstruction_maps(df, dt_string)
     create_obstruction_map_video(df, dt_string, 5)
+
     print("start: ", df.iloc[0]["timestamp"])
     print("end: ", df.iloc[-1]["timestamp"])
 
     if config.LATITUDE and config.LONGITUDE and config.ALTITUDE:
+        SINR_FILENAME = "{}/{}/PhyRxBeamSnrAvg-{}.csv".format(
+            GRPC_DATA_DIR, date, dt_string
+        )
+        df_sinr = pd.read_csv(SINR_FILENAME)
         estimate_connected_satellites(
-            dt_string, date, df.iloc[0]["timestamp"], df.iloc[-1]["timestamp"]
+            dt_string,
+            date,
+            frame_type_int,
+            df_sinr,
+            df.iloc[0]["timestamp"],
+            df.iloc[-1]["timestamp"],
         )
 
 
-def estimate_connected_satellites(uuid, date, start, end):
+def estimate_connected_satellites(uuid, date, frame_type, df_sinr, start, end):
     start_ts = datetime.fromtimestamp(start, tz=timezone.utc)
     end_ts = datetime.fromtimestamp(end, tz=timezone.utc)
 
-    convert_observed(DATA_DIR, f"obstruction-data-{uuid}.csv")
+    convert_observed(DATA_DIR, f"obstruction-data-{uuid}.csv", frame_type, df_sinr)
 
     filename = f"{DATA_DIR}/obstruction-data-{uuid}.csv"
     merged_data_file = f"{DATA_DIR}/processed_obstruction-data-{uuid}.csv"
@@ -234,6 +244,7 @@ def estimate_connected_satellites(uuid, date, start, end):
         end_ts.second,
         merged_data_file,
         satellites,
+        frame_type,
     )
 
     merged_data_df = pd.read_csv(merged_data_file, parse_dates=["Timestamp"])

--- a/starlink/dish.py
+++ b/starlink/dish.py
@@ -62,7 +62,7 @@ def get_sinr():
     name = "GRPC_phyRxBeamSnrAvg"
     logger.info("{}, {}".format(name, threading.current_thread()))
 
-    FILENAME = "{}/{}/PhyRxBeamSnrAvg-{}.csv".format(
+    FILENAME = "{}/{}/GRPC_STATUS-{}.csv".format(
         GRPC_DATA_DIR, ensure_data_directory(GRPC_DATA_DIR), date_time_string()
     )
 
@@ -82,6 +82,9 @@ def get_sinr():
                 [
                     "timestamp",
                     "sinr",
+                    "popPingLatencyMs",
+                    "downlinkThroughputBps",
+                    "uplinkThroughputBps",
                     "tiltAngleDeg",
                     "boresightAzimuthDeg",
                     "boresightElevationDeg",
@@ -101,10 +104,17 @@ def get_sinr():
                 ):
                     sinr = data["dishGetStatus"]["phyRxBeamSnrAvg"]
                     alignment = data["dishGetStatus"]["alignmentStats"]
+                    status = data["dishGetStatus"]
+                    popPingLatencyMs = status.get("popPingLatencyMs", 0)
+                    dlThroughputBps = status.get("downlinkThroughputBps", 0)
+                    upThroughputBps = status.get("uplinkThroughputBps", 0)
                     csv_writer.writerow(
                         [
                             time.time(),
                             sinr,
+                            popPingLatencyMs,
+                            dlThroughputBps,
+                            upThroughputBps,
                             alignment["tiltAngleDeg"],
                             alignment["boresightAzimuthDeg"],
                             alignment["boresightElevationDeg"],
@@ -201,7 +211,7 @@ def get_obstruction_map():
     print("end: ", df.iloc[-1]["timestamp"])
 
     if config.LATITUDE and config.LONGITUDE and config.ALTITUDE:
-        SINR_FILENAME = "{}/{}/PhyRxBeamSnrAvg-{}.csv".format(
+        SINR_FILENAME = "{}/{}/GRPC_STATUS-{}.csv".format(
             GRPC_DATA_DIR, date, dt_string
         )
         df_sinr = pd.read_csv(SINR_FILENAME)

--- a/starlink/main.py
+++ b/starlink/main.py
@@ -6,7 +6,11 @@ import schedule
 
 import config
 from latency import icmp_ping
-from dish import grpc_get_status, get_sinr, get_obstruction_map
+from dish import (
+    grpc_get_status,
+    get_sinr,
+    get_obstruction_map,
+)
 from util import run, load_tle
 from config import print_config
 

--- a/starlink/obstruction.py
+++ b/starlink/obstruction.py
@@ -9,8 +9,6 @@ import cv2
 import pandas as pd
 import numpy as np
 
-FRAME_TYPE = "FRAME_EARTH"
-
 
 def process_obstruction_maps(df_obstruction_map, uuid):
     start_time_dt = datetime.fromtimestamp(

--- a/starlink/plot.py
+++ b/starlink/plot.py
@@ -22,7 +22,7 @@ from util import load_ping, load_tle_from_file, load_connected_satellites
 from pop import get_pop_data
 from pprint import pprint
 
-FRAME_TYPE = "FRAME_EARTH"
+FRAME_TYPE = ""
 POP_DATA = None
 
 centralLat = None

--- a/starlink/plot.py
+++ b/starlink/plot.py
@@ -65,9 +65,9 @@ def plot_once(row, df_obstruction_map, df_rtt, df_sinr, all_satellites):
     if frame_type_int == 0:
         FRAME_TYPE = "UNKNOWN"
     elif frame_type_int == 1:
-        FRAME_TYPE = "EARTH"
+        FRAME_TYPE = "FRAME_EARTH"
     elif frame_type_int == 2:
-        FRAME_TYPE = "UT"
+        FRAME_TYPE = "FRAME_UT"
 
     currentObstructionMap = get_obstruction_map_by_timestamp(
         df_obstruction_map, timestamp_str
@@ -129,7 +129,7 @@ def plot_once(row, df_obstruction_map, df_rtt, df_sinr, all_satellites):
                 name,
                 transform=projPlateCarree,
                 fontsize=10,
-                color="black",
+                color="red",
                 wrap=True,
                 clip_on=True,
             )

--- a/starlink/plot.py
+++ b/starlink/plot.py
@@ -401,7 +401,7 @@ if __name__ == "__main__":
     OBSTRUCTION_MAP_DATA = Path(DATA_DIR).joinpath(
         f"grpc/{DATE}/obstruction_map-{DATE_TIME}.parquet"
     )
-    SINR_DATA = Path(DATA_DIR).joinpath(f"grpc/{DATE}/PhyRxBeamSnrAvg-{DATE_TIME}.csv")
+    SINR_DATA = Path(DATA_DIR).joinpath(f"grpc/{DATE}/GRPC_STATUS-{DATE_TIME}.csv")
     LATENCY_DATA = Path(DATA_DIR).joinpath(f"latency/{DATE}/ping-10ms-{DATE_TIME}.txt")
     TLE_DATA = Path(DATA_DIR).joinpath(f"TLE/{DATE}/starlink-tle-{DATE_TIME}.txt")
 

--- a/starlink/plot.py
+++ b/starlink/plot.py
@@ -22,7 +22,6 @@ from util import load_ping, load_tle_from_file, load_connected_satellites
 from pop import get_pop_data
 from pprint import pprint
 
-FRAME_TYPE = ""
 POP_DATA = None
 
 centralLat = None
@@ -62,6 +61,14 @@ def plot_once(row, df_obstruction_map, df_rtt, df_sinr, all_satellites):
     # axObstructionMapCumulative = fig.add_subplot(gs00[3, 0])
     axObstructionMapInstantaneous = fig.add_subplot(gs00[3, :])
 
+    frame_type_int = df_obstruction_map["frame_type"].iloc[0]
+    if frame_type_int == 0:
+        FRAME_TYPE = "UNKNOWN"
+    elif frame_type_int == 1:
+        FRAME_TYPE = "EARTH"
+    elif frame_type_int == 2:
+        FRAME_TYPE = "UT"
+
     currentObstructionMap = get_obstruction_map_by_timestamp(
         df_obstruction_map, timestamp_str
     )
@@ -70,7 +77,7 @@ def plot_once(row, df_obstruction_map, df_rtt, df_sinr, all_satellites):
         cmap="gray",
     )
     axObstructionMapInstantaneous.set_title(
-        f"Instantaneous gRPC obstruction map, frame type: {FRAME_TYPE}"
+        f"Instantaneous gRPC obstruction map in current timeslot, frame type: {FRAME_TYPE}"
     )
 
     axSat.set_extent(

--- a/starlink/satellites.py
+++ b/starlink/satellites.py
@@ -37,12 +37,12 @@ def pre_process_observed_data(filename, frame_type, df_sinr):
         elif frame_type_str == "FRAME_UT":
             dx, dy = point["X"] - observer_x, point["Y"] - observer_y
         radius = np.sqrt(dx**2 + dy**2) * pixel_to_degrees
+        azimuth = np.degrees(np.arctan2(dx, dy))
         if frame_type_str == "FRAME_EARTH":
-            azimuth = np.degrees(np.arctan2(dx, dy))
+            azimuth = (azimuth + 360) % 360
         elif frame_type_str == "FRAME_UT":
             azimuth = (azimuth + _rotation_az + 360) % 360
         # Normalize the azimuth to ensure it's within 0 to 360 degrees
-        azimuth = (azimuth + 360) % 360
         elevation = 90 - radius
         positions.append(
             (point["Timestamp"], point["Y"], point["X"], elevation, azimuth)


### PR DESCRIPTION
For Starlink obstruction map, map reference frame `FRAME_UT` is mainly seen in `inactive`/`mobile`/`roaming` dishes. 
`popPingLatencyMs`, `downlinkThroughputBps`, `uplinkThroughputBps` from gRPC interface is also collected for potential use cases, but not visualized in the plots.