### PR TITLE
process obstruction map data for each timeslot during measurements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+extend-ignore = E501
+exclude = .git,__pycache__,docs/source/conf.py,old,build,dist

--- a/starlink/satellites.py
+++ b/starlink/satellites.py
@@ -1,6 +1,7 @@
 # flake8: noqa:E501
 
 import math
+import logging
 import config
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -8,6 +9,8 @@ from pathlib import Path
 import pandas as pd
 import numpy as np
 from skyfield.api import load, wgs84, utc
+
+logger = logging.getLogger(__name__)
 
 
 def pre_process_observed_data(filename, frame_type, df_sinr):


### PR DESCRIPTION
Fix #10, #11 

Process obstruction map data for each timeslot during measurements. In this case, the connected satellites are estimated after the current timeslot ends.

For example, if the measurement container is created with the following parameters:

```bash
docker run -it --rm \
  -v ./data:/app/starlink/data \
  -e DURATION=10m \
  --network host \
  clarkzjw/leoviz:starlink-test \
  poetry run python3 main.py --run-once --lat ...
```

The following files will be updated every 15 seconds.

```
obstruction-data-*.csv
processed_obstruction-data-*.csv
serving_satellite_data-*.csv
```

The obstruction map video is still created after the entire measurement ends as defined by DURATION. 