### PR TITLE
Log lon, lat, and alt in status

### DIFF
--- a/starlink/config.py
+++ b/starlink/config.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 LATITUDE = None
 LONGITUDE = None
 ALTITUDE = None
+MOBILE = False
 
 IFCE = os.getenv("IFCE", "")
 


### PR DESCRIPTION
feat: Add support for mobile experiments with location and orientation logging

This commit introduces initial support for mobile Starlink experiments by logging dynamic location data (latitude, longitude, altitude) as well as orientation using quaternion coordinates. This enhancement is essential for experiments involving moving terminals, where geospatial and directional changes over time need to be captured for accurate analysis.

